### PR TITLE
Trocar link do curso no README?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scrapy_cultural_sp
 Scrapy scripts para extrair programação da virada cultural paulista 2016.
-Esse projeto é apresentado na vídeo [aula sobre Scrapy](https://www.youtube.com/watch?v=rj8Sqsgh5TM) do curso de [Introdução à Ciência da Computação com Python Parte 1](https://www.coursera.org/learn/ciencia-computacao-python-conceitos) criado pela CCSL IME-USP
+Esse projeto é apresentado na vídeo [aula sobre Scrapy](https://www.youtube.com/watch?v=rj8Sqsgh5TM) do curso de [Introdução à Ciência da Computação com Python Parte 2](https://www.coursera.org/learn/ciencia-computacao-python-conceitos-2) criado pela CCSL IME-USP
 
 ## Requisitos para a instalação
 Para rodar a versão atual do Scrapy cultural SP, é necessário:


### PR DESCRIPTION
Oi @besson, tudo bem?

O link atual do README referencia a Parte 1 do curso, enquanto que a aula de scrapy se encontra na Parte 2. Tomei a liberdade de trocar.

Caso isso tenha sido proposital, desconsidere :)